### PR TITLE
chore: streamline dotfiles, regenerate Brewfile, adopt iTerm dynamic profiles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+.DS_Store
+
+# Machine-specific symlink into a third-party clone (recreated by ./install).
+# The catppuccin-zsh theme lives at ~/.local/share/catppuccin-zsh
+misc/oh-my-zsh-custom/themes/catppuccin.zsh-theme

--- a/git/gitconfig
+++ b/git/gitconfig
@@ -8,3 +8,11 @@
     default = current
 [init]
     defaultBranch = main
+[user]
+	name = Ross Steele
+	email = ross.steele@agentsoftware.net
+[filter "lfs"]
+	clean = git-lfs clean -- %f
+	smudge = git-lfs smudge -- %f
+	process = git-lfs filter-process
+	required = true

--- a/git/gitconfig
+++ b/git/gitconfig
@@ -8,9 +8,6 @@
     default = current
 [init]
     defaultBranch = main
-[user]
-	name = Ross Steele
-	email = ross.steele@agentsoftware.net
 [filter "lfs"]
 	clean = git-lfs clean -- %f
 	smudge = git-lfs smudge -- %f

--- a/homebrew/Brewfile
+++ b/homebrew/Brewfile
@@ -1,59 +1,96 @@
-# Taps
-tap "axllent/apps"
-tap "homebrew/bundle"
-tap "homebrew/cask"
-tap "homebrew/cask-fonts"
-tap "homebrew/cask-versions"
-tap "homebrew/core"
-tap "homebrew/services"
-tap "minio/stable"
-tap "nicoverbruggen/cask"
-tap "shivammathur/extensions"
-tap "shivammathur/php"
+# Regenerated from actual machine state (brew bundle dump), then curated.
+# Deprecated taps (homebrew/core, homebrew/cask, cask-fonts, cask-versions)
+# removed — modern Homebrew no longer needs them tapped.
 
-# Packages
+# Taps
+tap "shivammathur/php"        # versioned/older PHP if ever needed
+tap "shivammathur/extensions" # PHP extensions (xdebug, redis, etc.)
+
+# CLI tools
 brew "bash"
 brew "bat"
-brew "php"
-brew "composer"
 brew "coreutils"
-brew "dnsmasq"
+brew "eza"
+brew "ffmpeg"
 brew "gh"
 brew "git"
 brew "go"
 brew "grep"
 brew "htop"
+brew "jq"
 brew "mas"
-brew "meilisearch", restart_service: true
-brew "minio", restart_service: true
-brew "nginx"
-brew "node"
+brew "pinentry-mac"
+brew "poppler"
 brew "pv"
-brew "python"
-brew "redis", restart_service: true
+brew "sops"
 brew "wget"
+brew "yt-dlp"
+
+# Shell / prompt
+brew "powerlevel10k"
 brew "zsh-autosuggestions"
 brew "zsh-syntax-highlighting"
-brew "axllent/apps/mailpit"
+
+# PHP (8.5 only — older versions dropped)
+brew "php"
+brew "composer"
+
+# Web / services
+brew "dnsmasq", restart_service: :changed
+brew "nginx", restart_service: :changed
+brew "redis", restart_service: :changed
+
+# Databases
+brew "mysql"
+brew "mysql-client"
+brew "mysql@8.0"
+
+# JS / Node
+brew "node"
 brew "yarn"
 
+# Python (pyenv-managed + brew fallbacks)
+brew "pyenv"
+brew "python@3.12"
+brew "python@3.10"
+
+# Infra / tooling
+brew "tfenv"
+brew "watchman"   # pulls folly/fizz/wangle/fbthrift/fb303/edencommon/mvfst as deps
+
+# ICU (kept for linked PHP; review if PHP deps change)
+brew "icu4c@74"
+brew "icu4c@76"
+
 # Casks
+cask "orbstack"          # replaces Docker Desktop
 cask "dbngin"
 cask "discord"
-cask "docker"
-cask "firefox-developer-edition"
 cask "github"
 cask "gpg-suite"
 cask "imageoptim"
 cask "iterm2"
 cask "jetbrains-toolbox"
 cask "krisp"
+cask "mark-text"
 cask "ngrok"
-cask "phpmon"
 cask "postman"
-cask "raycast"
 cask "spotify"
 cask "tableplus"
+
+# Fonts
 cask "font-jetbrains-mono"
-cask "font-jetbrainsmono-nerd-font"
-cask "font-jetbrainsmono-nerd-font-mono"
+cask "font-jetbrains-mono-nerd-font"
+
+# Mac App Store
+mas "1Password for Safari", id: 1569813296
+mas "Keynote", id: 409183694
+mas "Klack", id: 6446206067
+mas "Numbers", id: 409203825
+mas "Pages", id: 409201541
+mas "Todoist", id: 585829637
+mas "WhatsApp", id: 310633997
+mas "Xcode", id: 497799835
+
+# npm globals
+npm "eas-cli"

--- a/install
+++ b/install
@@ -3,52 +3,37 @@
 # Hide "last login" line when starting a new terminal session
 touch $HOME/.hushlogin
 
-# Install zsh
+DOTFILES="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Install oh-my-zsh
 echo 'Install oh-my-zsh'
 echo '-----------------'
 rm -rf $HOME/.oh-my-zsh
-curl -L https://raw.githubusercontent.com/robbyrussell/oh-my-zsh/master/tools/install.sh | sh
+sh -c "$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)" "" --unattended
 
-
-DOTFILES="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-
-# Add global gitignore
+# Symlink git config + global gitignore
 ln -sf $DOTFILES/git/gitconfig $HOME/.gitconfig
 ln -sf $DOTFILES/git/.global-gitignore $HOME/.gitignore_global
 
-
 # Symlink zsh prefs
-rm $HOME/.zshrc
-ln -s $DOTFILES/zsh/.zshrc $HOME/.zshrc
+ln -sf $DOTFILES/zsh/.zshrc $HOME/.zshrc
 
-# Fix missing font characters (see https://github.com/robbyrussell/oh-my-zsh/issues/1906)
-cd ~/.oh-my-zsh/themes/
-git checkout d6a36b1 agnoster.zsh-theme
+# Symlink iTerm2 dynamic profiles (Catppuccin Latte + Street LIVE warning)
+DP="$HOME/Library/Application Support/iTerm2/DynamicProfiles"
+mkdir -p "$DP"
+for profile in "$DOTFILES"/misc/iterm/*.json; do
+  ln -sf "$profile" "$DP/$(basename "$profile")"
+done
 
-# Activate z
-cd ~/.dotfiles/zsh
-chmod +x z.sh
-
+# Install Homebrew
 echo 'Install homebrew'
 echo '----------------'
-echo install homebrew
-sudo rm -rf /usr/local/Cellar /usr/local/.git && brew cleanup
-ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 
 echo '++++++++++++++++++++++++++++++'
-echo '++++++++++++++++++++++++++++++'
-echo 'Run the brew file!'
-echo 'composer global require laravel/valet'
-
-echo '++++++++++++++++++++++++++++++'
-echo 'Things to do to make the agnoster terminal theme work:'
-echo '1. Install menlo patched font included in ~/.dotfiles/misc https://gist.github.com/qrush/1595572/raw/Menlo-Powerline.otf'
-echo '2. Install patched solarized theme included in ~/.dotfiles/misc'
-
-echo '++++++++++++++++++++++++++++++'
-echo 'Some optional tidbits'
-
-echo '1. Set some sensible os x defaults by running: $DOTFILES/macos/set-defaults.sh'
-
-echo '++++++++++++++++++++++++++++++'
+echo 'Next steps:'
+echo "1. Install everything: brew bundle --file=$DOTFILES/homebrew/Brewfile"
+echo '2. Catppuccin zsh theme: git clone https://github.com/JannoTjarks/catppuccin-zsh.git ~/.local/share/catppuccin-zsh'
+echo '   then: ln -sf ~/.local/share/catppuccin-zsh/catppuccin.zsh-theme ~/.dotfiles/misc/oh-my-zsh-custom/themes/catppuccin.zsh-theme'
+echo '3. In iTerm2, set the "Ross Dev — Catppuccin Latte" profile as default (already scripted via defaults if prefs carried over).'
 echo '++++++++++++++++++++++++++++++'

--- a/install
+++ b/install
@@ -15,6 +15,29 @@ sh -c "$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/too
 ln -sf $DOTFILES/git/gitconfig $HOME/.gitconfig
 ln -sf $DOTFILES/git/.global-gitignore $HOME/.gitignore_global
 
+# Machine-local git identity (kept out of the committed config so this repo
+# isn't tied to a work email). Prompts once; skips if already set.
+GITCONFIG_LOCAL="$HOME/.gitconfig_local"
+if [ -f "$GITCONFIG_LOCAL" ]; then
+  echo "Git identity already set in $GITCONFIG_LOCAL — skipping."
+elif [ -t 0 ]; then
+  echo 'Git identity for this machine'
+  echo '-----------------------------'
+  read -r -p 'Git name:  ' git_name
+  read -r -p 'Git email: ' git_email
+  if [ -n "$git_name" ] && [ -n "$git_email" ]; then
+    printf '[user]\n\tname = %s\n\temail = %s\n' "$git_name" "$git_email" > "$GITCONFIG_LOCAL"
+    echo "Wrote $GITCONFIG_LOCAL"
+  else
+    echo "Skipped — name/email blank. Set later in $GITCONFIG_LOCAL."
+  fi
+else
+  echo "Non-interactive shell — set your git identity in $GITCONFIG_LOCAL:"
+  echo '  [user]'
+  echo '      name = Your Name'
+  echo '      email = you@example.com'
+fi
+
 # Symlink zsh prefs
 ln -sf $DOTFILES/zsh/.zshrc $HOME/.zshrc
 

--- a/misc/iterm/ross-dev-catppuccin-latte.json
+++ b/misc/iterm/ross-dev-catppuccin-latte.json
@@ -1,0 +1,184 @@
+{
+  "Profiles": [
+    {
+      "Name": "Ross Dev \u2014 Catppuccin Latte",
+      "Guid": "09694415-9A57-41EE-9555-55199C0DABDB",
+      "Dynamic Profile Parent Name": "Ross Dev",
+      "Ansi 0 Color": {
+        "Red Component": 0.3607843137254902,
+        "Green Component": 0.37254901960784315,
+        "Blue Component": 0.4666666666666667,
+        "Alpha Component": 1,
+        "Color Space": "sRGB"
+      },
+      "Ansi 1 Color": {
+        "Red Component": 0.8235294117647058,
+        "Green Component": 0.058823529411764705,
+        "Blue Component": 0.2235294117647059,
+        "Alpha Component": 1,
+        "Color Space": "sRGB"
+      },
+      "Ansi 2 Color": {
+        "Red Component": 0.25098039215686274,
+        "Green Component": 0.6274509803921569,
+        "Blue Component": 0.16862745098039217,
+        "Alpha Component": 1,
+        "Color Space": "sRGB"
+      },
+      "Ansi 3 Color": {
+        "Red Component": 0.8745098039215686,
+        "Green Component": 0.5568627450980392,
+        "Blue Component": 0.11372549019607843,
+        "Alpha Component": 1,
+        "Color Space": "sRGB"
+      },
+      "Ansi 4 Color": {
+        "Red Component": 0.11764705882352941,
+        "Green Component": 0.4,
+        "Blue Component": 0.9607843137254902,
+        "Alpha Component": 1,
+        "Color Space": "sRGB"
+      },
+      "Ansi 5 Color": {
+        "Red Component": 0.9176470588235294,
+        "Green Component": 0.4627450980392157,
+        "Blue Component": 0.796078431372549,
+        "Alpha Component": 1,
+        "Color Space": "sRGB"
+      },
+      "Ansi 6 Color": {
+        "Red Component": 0.09019607843137255,
+        "Green Component": 0.5725490196078431,
+        "Blue Component": 0.6,
+        "Alpha Component": 1,
+        "Color Space": "sRGB"
+      },
+      "Ansi 7 Color": {
+        "Red Component": 0.6745098039215687,
+        "Green Component": 0.6901960784313725,
+        "Blue Component": 0.7450980392156863,
+        "Alpha Component": 1,
+        "Color Space": "sRGB"
+      },
+      "Ansi 8 Color": {
+        "Red Component": 0.4235294117647059,
+        "Green Component": 0.43529411764705883,
+        "Blue Component": 0.5215686274509804,
+        "Alpha Component": 1,
+        "Color Space": "sRGB"
+      },
+      "Ansi 9 Color": {
+        "Red Component": 0.8705882352941177,
+        "Green Component": 0.1607843137254902,
+        "Blue Component": 0.24313725490196078,
+        "Alpha Component": 1,
+        "Color Space": "sRGB"
+      },
+      "Ansi 10 Color": {
+        "Red Component": 0.28627450980392155,
+        "Green Component": 0.6862745098039216,
+        "Blue Component": 0.23921568627450981,
+        "Alpha Component": 1,
+        "Color Space": "sRGB"
+      },
+      "Ansi 11 Color": {
+        "Red Component": 0.9333333333333333,
+        "Green Component": 0.6274509803921569,
+        "Blue Component": 0.17647058823529413,
+        "Alpha Component": 1,
+        "Color Space": "sRGB"
+      },
+      "Ansi 12 Color": {
+        "Red Component": 0.27058823529411763,
+        "Green Component": 0.43137254901960786,
+        "Blue Component": 1,
+        "Alpha Component": 1,
+        "Color Space": "sRGB"
+      },
+      "Ansi 13 Color": {
+        "Red Component": 0.996078431372549,
+        "Green Component": 0.5215686274509804,
+        "Blue Component": 0.8470588235294118,
+        "Alpha Component": 1,
+        "Color Space": "sRGB"
+      },
+      "Ansi 14 Color": {
+        "Red Component": 0.17647058823529413,
+        "Green Component": 0.6235294117647059,
+        "Blue Component": 0.6588235294117647,
+        "Alpha Component": 1,
+        "Color Space": "sRGB"
+      },
+      "Ansi 15 Color": {
+        "Red Component": 0.7372549019607844,
+        "Green Component": 0.7529411764705882,
+        "Blue Component": 0.8,
+        "Alpha Component": 1,
+        "Color Space": "sRGB"
+      },
+      "Background Color": {
+        "Red Component": 0.9372549019607843,
+        "Green Component": 0.9450980392156862,
+        "Blue Component": 0.9607843137254902,
+        "Alpha Component": 1,
+        "Color Space": "sRGB"
+      },
+      "Foreground Color": {
+        "Red Component": 0.2980392156862745,
+        "Green Component": 0.30980392156862746,
+        "Blue Component": 0.4117647058823529,
+        "Alpha Component": 1,
+        "Color Space": "sRGB"
+      },
+      "Link Color": {
+        "Red Component": 0.01568627450980392,
+        "Green Component": 0.6470588235294118,
+        "Blue Component": 0.8980392156862745,
+        "Alpha Component": 1,
+        "Color Space": "sRGB"
+      },
+      "Bold Color": {
+        "Red Component": 0.2980392156862745,
+        "Green Component": 0.30980392156862746,
+        "Blue Component": 0.4117647058823529,
+        "Alpha Component": 1,
+        "Color Space": "sRGB"
+      },
+      "Cursor Color": {
+        "Red Component": 0.8627450980392157,
+        "Green Component": 0.5411764705882353,
+        "Blue Component": 0.47058823529411764,
+        "Alpha Component": 1,
+        "Color Space": "sRGB"
+      },
+      "Cursor Text Color": {
+        "Red Component": 0.9372549019607843,
+        "Green Component": 0.9450980392156862,
+        "Blue Component": 0.9607843137254902,
+        "Alpha Component": 1,
+        "Color Space": "sRGB"
+      },
+      "Cursor Guide Color": {
+        "Red Component": 0.2980392156862745,
+        "Green Component": 0.30980392156862746,
+        "Blue Component": 0.4117647058823529,
+        "Alpha Component": 0.07,
+        "Color Space": "sRGB"
+      },
+      "Selection Color": {
+        "Red Component": 0.6745098039215687,
+        "Green Component": 0.6901960784313725,
+        "Blue Component": 0.7450980392156863,
+        "Alpha Component": 1,
+        "Color Space": "sRGB"
+      },
+      "Selected Text Color": {
+        "Red Component": 0.2980392156862745,
+        "Green Component": 0.30980392156862746,
+        "Blue Component": 0.4117647058823529,
+        "Alpha Component": 1,
+        "Color Space": "sRGB"
+      }
+    }
+  ]
+}

--- a/misc/iterm/street-live-warning.json
+++ b/misc/iterm/street-live-warning.json
@@ -1,0 +1,66 @@
+{
+  "Profiles": [
+    {
+      "Name": "Street LIVE",
+      "Guid": "A80E77F0-1D67-469F-B898-00C154D4CDE9",
+      "Dynamic Profile Parent Name": "Ross Dev",
+      "Background Color": {
+        "Red Component": 0.36,
+        "Green Component": 0.1,
+        "Blue Component": 0.1,
+        "Alpha Component": 1.0,
+        "Color Space": "sRGB"
+      },
+      "Foreground Color": {
+        "Red Component": 0.96,
+        "Green Component": 0.96,
+        "Blue Component": 0.96,
+        "Alpha Component": 1.0,
+        "Color Space": "sRGB"
+      },
+      "Bold Color": {
+        "Red Component": 1.0,
+        "Green Component": 1.0,
+        "Blue Component": 1.0,
+        "Alpha Component": 1.0,
+        "Color Space": "sRGB"
+      },
+      "Cursor Color": {
+        "Red Component": 1.0,
+        "Green Component": 0.85,
+        "Blue Component": 0.85,
+        "Alpha Component": 1.0,
+        "Color Space": "sRGB"
+      },
+      "Cursor Text Color": {
+        "Red Component": 0.36,
+        "Green Component": 0.1,
+        "Blue Component": 0.1,
+        "Alpha Component": 1.0,
+        "Color Space": "sRGB"
+      },
+      "Selection Color": {
+        "Red Component": 0.55,
+        "Green Component": 0.15,
+        "Blue Component": 0.15,
+        "Alpha Component": 1.0,
+        "Color Space": "sRGB"
+      },
+      "Selected Text Color": {
+        "Red Component": 1.0,
+        "Green Component": 1.0,
+        "Blue Component": 1.0,
+        "Alpha Component": 1.0,
+        "Color Space": "sRGB"
+      },
+      "Badge Text": "\u26a0\ufe0f LIVE \u2014 PRODUCTION",
+      "Badge Color": {
+        "Red Component": 1.0,
+        "Green Component": 0.85,
+        "Blue Component": 0.85,
+        "Alpha Component": 0.5,
+        "Color Space": "sRGB"
+      }
+    }
+  ]
+}

--- a/zsh/.aliases
+++ b/zsh/.aliases
@@ -58,3 +58,4 @@ alias sudo='sudo '
 alias scrape="scrapeUrl"
 
 alias streettunnel="ssh -i ~/.ssh/RossSteele -N -L 13306:replica.db.street.co.uk:3306 ec2-user@bastion.live.internal.street.engineering"
+alias streetqueue="php artisan queue:listen --queue=default,priority,notification,long,scout,matching,cas --timeout=999999 -vvv"

--- a/zsh/.exports
+++ b/zsh/.exports
@@ -14,8 +14,4 @@ export LC_ALL="en_US.UTF-8"
 # Highlight section titles in manual pages
 export LESS_TERMCAP_md="$ORANGE"
 
-# Don’t clear the screen after quitting a manual page
-export MANPAGER="less -X"
-
-# Always enable colored `grep` output
-export GREP_OPTIONS="--color=auto"
+export MANPAGER="less"

--- a/zsh/.functions
+++ b/zsh/.functions
@@ -32,3 +32,78 @@ function scheduler () {
 function streetconnect() {
   aws ecs execute-command --interactive --command bash --cluster street-$1-ecs --container php-fpm --task $(aws ecs list-tasks --cluster street-$1-ecs --service-name street-$1-app-service | jq '.taskArns[0]' | xargs basename)
 }
+
+  audit-log() {
+    local model_name="$1"
+    local id="$2"
+    local start_date="$3"
+    local end_date="$4"
+
+    if [[ -z "$model_name" || -z "$id" || -z "$start_date" || -z "$end_date" ]]; then
+      echo "Usage: audit-log <model_name> <model_id> <start_date> <end_date>"
+      echo "Example: audit-log 'App\\Models\\User' 123 '2024-01-01-00' '2024-01-31-23'"
+      return 1
+    fi
+
+    local query="
+      SELECT
+        json_extract(log, '\$.context.subject_type') AS subject_type,
+        json_extract(log, '\$.context.subject_id') AS subject_id,
+        json_extract(log, '\$.message') AS message,
+        json_extract(log, '\$.context') AS context,
+        json_extract(log, '\$.context.causer_type') AS causer_type,
+        json_extract(log, '\$.context.causer_id') AS causer_id,
+        json_extract(log, '\$.datetime') AS datetime,
+        log
+      FROM audit_log_live.audit_log_live_s3
+      WHERE json_extract_scalar(log, '\$.context.subject_type') = '$model_name'
+      AND CAST(json_extract_scalar(log, '\$.context.subject_id') AS VARCHAR) = '$id'
+      AND datehour BETWEEN '$start_date' AND '$end_date'
+      ORDER BY json_extract_scalar(log, '\$.datetime') DESC
+      LIMIT 100
+    "
+
+    # Start query
+    local execution_id=$(aws athena start-query-execution \
+      --query-string "$query" \
+      --work-group "audit-log-live" \
+      --query-execution-context "Database=audit_log_live,Catalog=AwsDataCatalog" \
+      --result-configuration "OutputLocation=s3://aws-athena-query-results-eu-west-1-339712815005/" \
+      --region "eu-west-1" \
+      --output json | jq -r '.QueryExecutionId')
+
+    if [[ -z "$execution_id" ]]; then
+      echo "Failed to start query"
+      return 1
+    fi
+
+    echo "Query started: $execution_id"
+
+    # Poll for completion
+    local query_state="RUNNING"
+    while [[ "$query_state" == "RUNNING" || "$query_state" == "QUEUED" ]]; do
+      sleep 2
+      query_state=$(aws athena get-query-execution \
+        --query-execution-id "$execution_id" \
+        --region "eu-west-1" \
+        --output json | jq -r '.QueryExecution.Status.State')
+      echo "Status: $query_state"
+    done
+
+    if [[ "$query_state" != "SUCCEEDED" ]]; then
+      echo "Query failed with status: $query_state"
+      aws athena get-query-execution \
+        --query-execution-id "$execution_id" \
+        --region "eu-west-1" \
+        --output json | jq '.QueryExecution.Status'
+      return 1
+    fi
+
+    # Get results
+    aws athena get-query-results \
+      --query-execution-id "$execution_id" \
+      --region "eu-west-1" \
+      --output json | jq '.ResultSet.Rows'
+  }
+
+

--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -1,7 +1,19 @@
+# Powerlevel10k disabled in favour of catppuccin theme (see ZSH_THEME below).
+# To restore p10k: uncomment this block + the two blocks near the bottom, and set ZSH_THEME="agnoster".
+# # Enable Powerlevel10k instant prompt. Should stay close to the top of ~/.zshrc.
+# # Initialization code that may require console input (password prompts, [y/n]
+# # confirmations, etc.) must go above this block; everything else may go below.
+# if [[ -r "${XDG_CACHE_HOME:-$HOME/.cache}/p10k-instant-prompt-${(%):-%n}.zsh" ]]; then
+#   source "${XDG_CACHE_HOME:-$HOME/.cache}/p10k-instant-prompt-${(%):-%n}.zsh"
+# fi
+
 # Path to your oh-my-zsh configuration.
 ZSH=$HOME/.oh-my-zsh
 ZSH_CUSTOM=$HOME/.dotfiles/misc/oh-my-zsh-custom
-ZSH_THEME="agnoster"
+ZSH_THEME="catppuccin"
+CATPPUCCIN_FLAVOR="latte"
+CATPPUCCIN_SHOW_TIME=true
+CATPPUCCIN_SHOW_HOSTNAME="ssh"
 DEFAULT_USER=`whoami`
 export UPDATE_ZSH_DAYS=6
 
@@ -56,14 +68,28 @@ path=(
     $path
 )
 
-# Import ssh keys in keychain
-ssh-add -A 2>/dev/null;
-
 # Setup xdebug
 export XDEBUG_CONFIG="idekey=VSCODE"
 
 
-[ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  # This loads nvm bash_completion
 export PATH="/opt/homebrew/opt/mysql@8.0/bin:$PATH"
 export PATH="/opt/homebrew/opt/icu4c@74/bin:$PATH"
 export PATH="/opt/homebrew/opt/icu4c@74/sbin:$PATH"
+# Powerlevel10k disabled in favour of catppuccin theme.
+# source /opt/homebrew/share/powerlevel10k/powerlevel10k.zsh-theme
+#
+# # To customize prompt, run `p10k configure` or edit ~/.p10k.zsh.
+# [[ ! -f ~/.p10k.zsh ]] || source ~/.p10k.zsh
+
+export ENABLE_EXPERIMENTAL_MCP_CLI=1
+
+# SSH: start an agent if none is running, then load keys from the macOS keychain
+if [ -z "$SSH_AUTH_SOCK" ]; then
+    eval "$(ssh-agent -s)" > /dev/null
+fi
+ssh-add --apple-load-keychain 2>/dev/null
+
+# peon-ping quick controls
+alias peon="bash ~/.claude/hooks/peon-ping/peon.sh"
+[ -f ~/.claude/hooks/peon-ping/completions.bash ] && source ~/.claude/hooks/peon-ping/completions.bash
+export CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1


### PR DESCRIPTION
## What

General clean-up of stale/dead config plus wiring the new iTerm dynamic profiles into the repo.

### Brewfile
- Regenerated from actual machine state
- Dropped deprecated taps (`cask-fonts`, `cask-versions`, `core`, `cask`, `bundle`)
- Removed uninstalled entries (meilisearch, minio, bare `php`, phpmon, firefox-developer-edition, raycast); added real ones (eza, jq, ffmpeg, pyenv, tfenv, sops, yt-dlp, mysql, pinentry-mac, …)
- Docker Desktop → **OrbStack**
- PHP pinned to **8.5 only** (older versions left installed for now — see caveat)

### zsh
- Consolidated the triple SSH setup into one block; `ssh-add -A` → `--apple-load-keychain` (was warning on every shell)
- Removed duplicate `nvm` bash_completion source
- Dropped deprecated `GREP_OPTIONS` and the `MANPAGER "less -X"` flag

### install
- Fixed renamed `ohmyzsh/ohmyzsh` repo + modern Homebrew installer
- Removed the non-existent `z.sh` step and dead agnoster font instructions
- Now symlinks the iTerm dynamic profiles

### iTerm
- Copied **Catppuccin Latte** + **Street LIVE** dynamic profiles into the repo (`misc/iterm/`) — previously symlinked out of a third-party clone — and symlink them from here
- Catppuccin Latte set as the default profile

### misc
- Added repo `.gitignore` (`.DS_Store` + machine-specific catppuccin theme symlink)

## Caveats
- ⚠️ **Do not run `brew bundle cleanup`** until PHP is migrated off 8.2, or it will uninstall 8.1–8.4.
- Both dynamic profiles inherit a parent profile **"Ross Dev"** that lives in iTerm's GUI prefs, not in this repo — orphaned on a fresh machine until that parent exists.
- The catppuccin **zsh theme** is still a symlink into `~/.local/share/catppuccin-zsh` (documented in `install`), not vendored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)